### PR TITLE
Rails 5.2 compatibility

### DIFF
--- a/core/refinerycms-core.gemspec
+++ b/core/refinerycms-core.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../../core/lib/refinery/version', __FILE__)
 
 version = Refinery::Version.to_s
-rails_version = ['>= 5.1.0', '< 5.2']
+rails_version = ['>= 5.1.0', '< 6.0']
 
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY

--- a/images/refinerycms-images.gemspec
+++ b/images/refinerycms-images.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'
-  s.add_dependency 'globalize',               ['>= 5.1.0.beta1', '< 5.2']
+  s.add_dependency 'globalize',               ['>= 5.1.0.beta1', '< 5.3']
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'refinerycms-core',        version
 

--- a/pages/refinerycms-pages.gemspec
+++ b/pages/refinerycms-pages.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'friendly_id',                 ['>= 5.1.0', '< 5.3']
-  s.add_dependency 'globalize',                   ['>= 5.1.0.beta1', '< 5.2']
+  s.add_dependency 'globalize',                   ['>= 5.1.0.beta1', '< 5.3']
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'awesome_nested_set',          '~> 3.1', '>= 3.1.0'
   s.add_dependency 'seo_meta',                    '~> 3.0', '>= 3.0.0'

--- a/resources/refinerycms-resources.gemspec
+++ b/resources/refinerycms-resources.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'acts_as_indexed',         '~> 0.8.0'
   s.add_dependency 'dragonfly',               '~> 1.1', '>= 1.1.0'
-  s.add_dependency 'globalize',               ['>= 5.1.0.beta1', '< 5.2']
+  s.add_dependency 'globalize',               ['>= 5.1.0.beta1', '< 5.3']
   s.add_dependency 'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'refinerycms-core',        version
   s.add_dependency 'refinerycms-dragonfly',   '~> 1.0'


### PR DESCRIPTION
Attempt at using 4-0-stable with Rails 5.2. Globalize also needs an update for it work. If we don't touch the project Gemfile.lock, nothing should change by this change, so I'm merging this.